### PR TITLE
Add utility methods to rank annotations

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/FeatureAnnotationPriority.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/FeatureAnnotationPriority.java
@@ -31,10 +31,13 @@ import io.github.mzmine.datamodel.features.types.annotations.CompoundDatabaseMat
 import io.github.mzmine.datamodel.features.types.annotations.LipidMatchListType;
 import io.github.mzmine.datamodel.features.types.annotations.ManualAnnotation;
 import io.github.mzmine.datamodel.features.types.annotations.ManualAnnotationType;
+import io.github.mzmine.datamodel.features.types.annotations.MissingValueType;
 import io.github.mzmine.datamodel.features.types.annotations.SpectralLibraryMatchesType;
 import io.github.mzmine.datamodel.features.types.annotations.formula.FormulaListType;
 import io.github.mzmine.datamodel.features.types.modifiers.AnnotationType;
+import io.github.mzmine.util.collections.CollectionUtils;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 
@@ -43,8 +46,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link FeatureAnnotationIterator}
  */
 public enum FeatureAnnotationPriority {
-  MANUAL(ManualAnnotationType.class), LIPID(LipidMatchListType.class), SPECTRAL_LIBRARY(
-      SpectralLibraryMatchesType.class), EXACT_COMPOUND(CompoundDatabaseMatchesType.class), FORMULA(
+  MANUAL(ManualAnnotationType.class), SPECTRAL_LIBRARY(
+      SpectralLibraryMatchesType.class), LIPID(LipidMatchListType.class), EXACT_COMPOUND(CompoundDatabaseMatchesType.class), FORMULA(
       FormulaListType.class);
   private static final DataType<?>[] dataTypes = Arrays.stream(FeatureAnnotationPriority.values())
       .map(FeatureAnnotationPriority::getAnnotationType).map(DataTypes::get)
@@ -54,6 +57,17 @@ public enum FeatureAnnotationPriority {
 
   FeatureAnnotationPriority(Class<? extends DataType<?>> clazz) {
     this.type = DataTypes.get(clazz);
+  }
+
+
+  /**
+   * Sort a collection of AnnotationTypes and put {@link MissingValueType} at the end
+   */
+  public static Comparator<DataType<?>> createDefaultSorter() {
+    var orderedTypes = CollectionUtils.indexMap(FeatureAnnotationPriority.getDataTypesInOrder());
+    orderedTypes.put(DataTypes.get(MissingValueType.class), orderedTypes.size());
+    return Comparator.comparing(orderedTypes::get,
+        Comparator.nullsLast(Comparator.naturalOrder()));
   }
 
   /**

--- a/mzmine-community/src/main/java/io/github/mzmine/util/ArrayUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/ArrayUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -26,6 +26,7 @@
 package io.github.mzmine.util;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 public class ArrayUtils {
 
@@ -48,10 +49,18 @@ public class ArrayUtils {
     }
   }
 
+  public static boolean contains(Object needle, Object[] haystack) {
+    for (final Object o : haystack) {
+      if (Objects.equals(o, needle)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public static <T> int indexOf(T needle, T[] haystack) {
     for (int i = 0; i < haystack.length; i++) {
-      if ((haystack[i] != null && haystack[i].equals(needle)) || (needle == null
-                                                                  && haystack[i] == null)) {
+      if (Objects.equals(haystack[i], needle)) {
         return i;
       }
     }
@@ -60,7 +69,7 @@ public class ArrayUtils {
 
   public static int indexOf(double needle, double[] haystack) {
     for (int i = 0; i < haystack.length; i++) {
-      if(Double.compare(haystack[i], needle) == 0) {
+      if (Double.compare(haystack[i], needle) == 0) {
         return i;
       }
     }
@@ -85,6 +94,7 @@ public class ArrayUtils {
     }
     return sum;
   }
+
   /**
    * @see #smallestDelta(double[], int)
    */
@@ -123,6 +133,7 @@ public class ArrayUtils {
 
   /**
    * Reverses the given array.
+   *
    * @param input The array.
    */
   public static void reverse(int[] input) {

--- a/mzmine-community/src/main/java/io/github/mzmine/util/DataTypeUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/DataTypeUtils.java
@@ -149,25 +149,24 @@ public class DataTypeUtils {
    *                         {@link MissingValueType} if this parameter is true. Otherwise they are
    *                         dropped.
    * @param allowedTypes     All allowed data types in the specific ranking order.
-   * @param <T>              The data types
    * @param <M>              A {@link io.github.mzmine.datamodel.features.ModularFeatureListRow} or
    *                         {@link ModularFeature}
    * @return A map of the specified types and the matching rows. The map is a tree map sorted
    * according to the hierarchy of the specified types.
    */
-  public static <T extends DataType<?>, M extends ModularDataModel> Map<T, List<M>> groupByBestDataType(
-      List<M> rows, boolean mapMissingValues, T... allowedTypes) {
+  public static <M extends ModularDataModel> Map<DataType<?>, List<M>> groupByBestDataType(
+      List<M> rows, boolean mapMissingValues, DataType<?>... allowedTypes) {
 
-    final Map<T, List<M>> results = new TreeMap<T, List<M>>(
+    final Map<DataType<?>, List<M>> results = new TreeMap<>(
         Comparator.comparingInt(o -> ArrayUtils.indexOf(allowedTypes, o)));
-    final T notAnnotatedType = (T) DataTypes.get(MissingValueType.class);
+
+    final var notAnnotatedType = mapMissingValues ? DataTypes.get(MissingValueType.class) : null;
 
     for (M row : rows) {
-      final T bestAnnotationType = getBestTypeWithValue(row,
-          mapMissingValues ? notAnnotatedType : null, allowedTypes);
+      final var bestAnnotationType = getBestTypeWithValue(row, notAnnotatedType, allowedTypes);
       if (bestAnnotationType != null) {
         final List<M> rowsWithAnnotation = results.computeIfAbsent(bestAnnotationType,
-            a -> new ArrayList<>());
+            _ -> new ArrayList<>());
         rowsWithAnnotation.add(row);
       }
     }
@@ -232,7 +231,7 @@ public class DataTypeUtils {
       final Object value = row.get((DataType<?>) allowedType);
       // if the annotation is a list we have to check if the list is not empty
       if (value != null && (!(value instanceof Collection<?> collection)
-          || !collection.isEmpty())) {
+                            || !collection.isEmpty())) {
         return allowedType;
       }
     }

--- a/mzmine-community/src/main/java/io/github/mzmine/util/annotations/CompoundAnnotationUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/annotations/CompoundAnnotationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2023 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -25,16 +25,95 @@
 
 package io.github.mzmine.util.annotations;
 
+import io.github.mzmine.datamodel.features.FeatureAnnotationPriority;
+import io.github.mzmine.datamodel.features.FeatureListRow;
 import io.github.mzmine.datamodel.features.compoundannotations.CompoundDBAnnotation;
+import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.DataTypes;
+import io.github.mzmine.datamodel.features.types.annotations.MissingValueType;
 import io.github.mzmine.datamodel.identities.iontype.IonType;
+import io.github.mzmine.util.ArrayUtils;
+import io.github.mzmine.util.DataTypeUtils;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.jetbrains.annotations.NotNull;
 
 public class CompoundAnnotationUtils {
+
+  /**
+   * @param rows             The rows to group
+   * @param mapMissingValues if none of the provided types is present, rows will be mapped to
+   *                         {@link MissingValueType} if this parameter is true. Otherwise they are
+   *                         dropped.
+   * @return A map of the annotation types and the matching rows. The map is a tree map sorted
+   * according to the hierarchy of the specified types.
+   */
+  @NotNull
+  public static Map<DataType<?>, List<FeatureListRow>> groupRowsByAnnotationPriority(
+      List<FeatureListRow> rows, boolean mapMissingValues) {
+    return DataTypeUtils.groupByBestDataType(rows, mapMissingValues,
+        FeatureAnnotationPriority.getDataTypesInOrder());
+  }
+
+  /**
+   * Get the best annotation types or {@link MissingValueType} for each feature list row.
+   *
+   * @param rows             the rows to be mapped.
+   * @param mapMissingValues true, add {@link MissingValueType}. Otherwise map will not contain null
+   *                         mapping for missing values. If true the map will be of rows.size
+   * @return a map of best annotation types per row
+   */
+  @NotNull
+  public static Map<FeatureListRow, DataType<?>> getAnnotationTypesByPriority(
+      List<FeatureListRow> rows, boolean mapMissingValues) {
+    var orderedTypes = FeatureAnnotationPriority.getDataTypesInOrder();
+    var notAnnotatedType = mapMissingValues ? DataTypes.get(MissingValueType.class) : null;
+
+    Map<FeatureListRow, DataType<?>> map = new HashMap<>();
+
+    for (final FeatureListRow row : rows) {
+      DataType<?> best = DataTypeUtils.getBestTypeWithValue(row, notAnnotatedType, orderedTypes);
+      if (best != null) {
+        map.put(row, best);
+      }
+    }
+    return map;
+  }
+
+  /**
+   * @param types can contain duplicates or nulls - that are filtered out
+   * @return map of DataType to their rank in
+   * {@link FeatureAnnotationPriority#getDataTypesInOrder()}. If {@link MissingValueType} is found,
+   * it is added as the last rank priority to the map
+   */
+  @NotNull
+  public static Map<DataType<?>, Integer> rankUniqueAnnotationTypes(Collection<DataType<?>> types) {
+    var orderedTypes = FeatureAnnotationPriority.getDataTypesInOrder();
+
+    AtomicBoolean containsMissing = new AtomicBoolean(false);
+    Map<DataType<?>, Integer> rankMap = new HashMap<>();
+    types.stream().filter(Objects::nonNull).distinct().forEach(type -> {
+      if (type instanceof MissingValueType) {
+        containsMissing.set(true);
+        return;
+      }
+      int index = ArrayUtils.indexOf(type, orderedTypes);
+      if (index >= 0) {
+        rankMap.put(type, index);
+      }
+    });
+    if (containsMissing.get()) {
+      rankMap.put(DataTypes.get(MissingValueType.class), rankMap.size());
+    }
+    return rankMap;
+  }
+
 
   /**
    * A list of matches where each entry has a different compound name.

--- a/mzmine-community/src/test/java/io/github/mzmine/util/annotations/CompoundAnnotationUtilsTest.java
+++ b/mzmine-community/src/test/java/io/github/mzmine/util/annotations/CompoundAnnotationUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2024 The MZmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -30,10 +30,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.github.mzmine.datamodel.features.compoundannotations.CompoundDBAnnotation;
 import io.github.mzmine.datamodel.features.compoundannotations.SimpleCompoundDBAnnotation;
+import io.github.mzmine.datamodel.features.types.DataType;
+import io.github.mzmine.datamodel.features.types.DataTypes;
 import io.github.mzmine.datamodel.features.types.annotations.CompoundNameType;
+import io.github.mzmine.datamodel.features.types.annotations.LipidMatchListType;
+import io.github.mzmine.datamodel.features.types.annotations.MissingValueType;
+import io.github.mzmine.datamodel.features.types.annotations.SmilesStructureType;
+import io.github.mzmine.datamodel.features.types.annotations.SpectralLibraryMatchesType;
+import io.github.mzmine.datamodel.features.types.annotations.formula.FormulaType;
 import io.github.mzmine.datamodel.features.types.annotations.iin.IonTypeType;
+import io.github.mzmine.datamodel.features.types.numbers.MZType;
 import io.github.mzmine.datamodel.identities.iontype.IonModification;
 import io.github.mzmine.datamodel.identities.iontype.IonType;
+import java.util.Collection;
 import java.util.List;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
@@ -94,5 +103,15 @@ class CompoundAnnotationUtilsTest {
 
     assertTrue(compoundB.getScore() <= compoundA.getScore(),
         "Score sorting descending did not work");
+  }
+
+  @Test
+  void rankUniqueAnnotationTypes() {
+    List<DataType> types = DataTypes.getAll(FormulaType.class, MZType.class, SmilesStructureType.class,
+        LipidMatchListType.class, SpectralLibraryMatchesType.class, MissingValueType.class,
+        MissingValueType.class);
+    var map = CompoundAnnotationUtils.rankUniqueAnnotationTypes((Collection) types);
+    assertEquals(3, map.size());
+    assertEquals(0, map.get(DataTypes.get(SpectralLibraryMatchesType.class)));
   }
 }

--- a/mzmine-community/src/test/java/util/DataTypeUtilsTest.java
+++ b/mzmine-community/src/test/java/util/DataTypeUtilsTest.java
@@ -64,7 +64,7 @@ public class DataTypeUtilsTest {
         spectralLipidAnnotated);
     final List<DataType> orderOne = DataTypes.getAll(LipidMatchListType.class,
         SpectralLibraryMatchesType.class);
-    final Map<DataType, List<FeatureListRow>> oderOneResult = DataTypeUtils.groupByBestDataType(
+    final Map<DataType<?>, List<FeatureListRow>> oderOneResult = DataTypeUtils.groupByBestDataType(
         rows, true, orderOne.toArray(DataType[]::new));
     Assertions.assertEquals(2, oderOneResult.get(new LipidMatchListType()).size());
     Assertions.assertEquals(1, oderOneResult.get(new SpectralLibraryMatchesType()).size());
@@ -72,7 +72,7 @@ public class DataTypeUtilsTest {
 
     final List<DataType> orderTwo = DataTypes.getAll(SpectralLibraryMatchesType.class,
         LipidMatchListType.class);
-    final Map<DataType, List<FeatureListRow>> oderTwoResult = DataTypeUtils.groupByBestDataType(
+    final Map<DataType<?>, List<FeatureListRow>> oderTwoResult = DataTypeUtils.groupByBestDataType(
         rows, false, orderTwo.toArray(DataType[]::new));
     Assertions.assertEquals(1, oderTwoResult.get(new LipidMatchListType()).size());
     Assertions.assertEquals(2, oderTwoResult.get(new SpectralLibraryMatchesType()).size());

--- a/utils/src/main/java/io/github/mzmine/util/collections/CollectionUtils.java
+++ b/utils/src/main/java/io/github/mzmine/util/collections/CollectionUtils.java
@@ -43,10 +43,12 @@ import java.util.stream.Stream;
 public class CollectionUtils {
 
   /**
-   * Map of the object to its index to avoid indexOf. This method will take any collection as input and this makes only sense if the collection has an order.
+   * Map of the object to its index to avoid indexOf. This method will take any collection as input
+   * and this makes only sense if the collection has an order.
+   *
    * @param list any collection
+   * @param <T>  the object to be mapped
    * @return Map object to index in collection
-   * @param <T> the object to be mapped
    */
   public static <T> Map<T, Integer> indexMap(Collection<T> list) {
     Map<T, Integer> map = new HashMap<>();
@@ -54,6 +56,20 @@ public class CollectionUtils {
     for (final T value : list) {
       map.put(value, i);
       i++;
+    }
+    return map;
+  }
+
+  /**
+   * Map of the object to its index to avoid indexOf.
+   *
+   * @param <T> the object to be mapped
+   * @return Map object to index in collection
+   */
+  public static <T> Map<T, Integer> indexMap(T[] array) {
+    Map<T, Integer> map = new HashMap<>();
+    for (int i = 0; i < array.length; i++) {
+      map.put(array[i], i);
     }
     return map;
   }

--- a/utils/src/main/java/io/github/mzmine/util/collections/CollectionUtils.java
+++ b/utils/src/main/java/io/github/mzmine/util/collections/CollectionUtils.java
@@ -28,9 +28,12 @@ package io.github.mzmine.util.collections;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -38,6 +41,22 @@ import java.util.stream.Stream;
  * Collection API related utilities
  */
 public class CollectionUtils {
+
+  /**
+   * Map of the object to its index to avoid indexOf. This method will take any collection as input and this makes only sense if the collection has an order.
+   * @param list any collection
+   * @return Map object to index in collection
+   * @param <T> the object to be mapped
+   */
+  public static <T> Map<T, Integer> indexMap(Collection<T> list) {
+    Map<T, Integer> map = new HashMap<>();
+    int i = 0;
+    for (final T value : list) {
+      map.put(value, i);
+      i++;
+    }
+    return map;
+  }
 
   /**
    * drops duplicate values using a HashSet. does not retain order


### PR DESCRIPTION
Added methods to CompoundAnnotationUtils to map and rank the best annotations in different ways.

In LoadingsProvider the getAnnotationTypesByPriority and rankUniqueAnnotationTypes now avoids indexOf lookups and can get the best annotaiton type directly from the map.
 