### PR TITLE
Fix annotation order

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/FeatureAnnotationPriority.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/datamodel/features/FeatureAnnotationPriority.java
@@ -35,10 +35,12 @@ import io.github.mzmine.datamodel.features.types.annotations.MissingValueType;
 import io.github.mzmine.datamodel.features.types.annotations.SpectralLibraryMatchesType;
 import io.github.mzmine.datamodel.features.types.annotations.formula.FormulaListType;
 import io.github.mzmine.datamodel.features.types.modifiers.AnnotationType;
-import io.github.mzmine.util.collections.CollectionUtils;
+import io.github.mzmine.util.collections.SortOrder;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -46,8 +48,8 @@ import org.jetbrains.annotations.NotNull;
  * {@link FeatureAnnotationIterator}
  */
 public enum FeatureAnnotationPriority {
-  MANUAL(ManualAnnotationType.class), SPECTRAL_LIBRARY(
-      SpectralLibraryMatchesType.class), LIPID(LipidMatchListType.class), EXACT_COMPOUND(CompoundDatabaseMatchesType.class), FORMULA(
+  MANUAL(ManualAnnotationType.class), SPECTRAL_LIBRARY(SpectralLibraryMatchesType.class), LIPID(
+      LipidMatchListType.class), EXACT_COMPOUND(CompoundDatabaseMatchesType.class), FORMULA(
       FormulaListType.class);
   private static final DataType<?>[] dataTypes = Arrays.stream(FeatureAnnotationPriority.values())
       .map(FeatureAnnotationPriority::getAnnotationType).map(DataTypes::get)
@@ -61,11 +63,26 @@ public enum FeatureAnnotationPriority {
 
 
   /**
-   * Sort a collection of AnnotationTypes and put {@link MissingValueType} at the end
+   * Sort a collection of AnnotationTypes and put {@link MissingValueType} at the end (descending)
+   * or at the start (ascending). For charts and legend creation use ACSENDING to put the missing
+   * color first
    */
-  public static Comparator<DataType<?>> createDefaultSorter() {
-    var orderedTypes = CollectionUtils.indexMap(FeatureAnnotationPriority.getDataTypesInOrder());
-    orderedTypes.put(DataTypes.get(MissingValueType.class), orderedTypes.size());
+  public static Comparator<? super DataType<?>> createSorter(final SortOrder order) {
+    Map<DataType<?>, Integer> orderedTypes = new LinkedHashMap<>();
+    int c = 0;
+    MissingValueType missingValueType = DataTypes.get(MissingValueType.class);
+    if (order == SortOrder.ASCENDING) {
+      orderedTypes.put(missingValueType, c++);
+      for (final DataType<?> type : FeatureAnnotationPriority.getDataTypesInReversedOrder()) {
+        orderedTypes.put(type, c++);
+      }
+    } else {
+      for (final DataType<?> type : FeatureAnnotationPriority.getDataTypesInOrder()) {
+        orderedTypes.put(type, c++);
+      }
+      orderedTypes.put(missingValueType, c);
+    }
+
     return Comparator.comparing(orderedTypes::get,
         Comparator.nullsLast(Comparator.naturalOrder()));
   }
@@ -91,9 +108,24 @@ public enum FeatureAnnotationPriority {
     return prio != null ? prio.ordinal() : FeatureAnnotationPriority.values().length;
   }
 
+  /**
+   * @return Best first
+   */
   public static DataType<?>[] getDataTypesInOrder() {
     return dataTypes;
   }
+
+  /**
+   * @return Best last
+   */
+  public static DataType<?>[] getDataTypesInReversedOrder() {
+    DataType<?>[] reversed = new DataType[dataTypes.length];
+    for (int i = 0; i < reversed.length; i++) {
+      reversed[i] = dataTypes[dataTypes.length - 1 - i];
+    }
+    return reversed;
+  }
+
 
   @NotNull
   public List<?> getAll(FeatureListRow row) {

--- a/mzmine-community/src/main/java/io/github/mzmine/util/annotations/CompoundAnnotationUtils.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/util/annotations/CompoundAnnotationUtils.java
@@ -35,6 +35,7 @@ import io.github.mzmine.datamodel.identities.iontype.IonType;
 import io.github.mzmine.util.ArrayUtils;
 import io.github.mzmine.util.DataTypeUtils;
 import io.github.mzmine.util.collections.CollectionUtils;
+import io.github.mzmine.util.collections.SortOrder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -87,16 +88,18 @@ public class CompoundAnnotationUtils {
   }
 
   /**
-   * @param types can contain duplicates or nulls - that are filtered out
+   * @param types     can contain duplicates or nulls - that are filtered out
+   * @param order order either ascending from missing to best match or reverse
    * @return map of DataType to their rank in
    * {@link FeatureAnnotationPriority#getDataTypesInOrder()}. If {@link MissingValueType} is found,
    * it is added as the last rank priority to the map
    */
   @NotNull
-  public static Map<DataType<?>, Integer> rankUniqueAnnotationTypes(Collection<DataType<?>> types) {
+  public static Map<DataType<?>, Integer> rankUniqueAnnotationTypes(Collection<DataType<?>> types,
+      @NotNull final SortOrder order) {
     var sortedUniqueTypes = types.stream().filter(Objects::nonNull).distinct()
         .filter(CompoundAnnotationUtils::isAnnotationOrMissingType)
-        .sorted(FeatureAnnotationPriority.createDefaultSorter()).toList();
+        .sorted(FeatureAnnotationPriority.createSorter(order)).toList();
     return CollectionUtils.indexMap(sortedUniqueTypes);
   }
 

--- a/mzmine-community/src/test/java/io/github/mzmine/util/annotations/CompoundAnnotationUtilsTest.java
+++ b/mzmine-community/src/test/java/io/github/mzmine/util/annotations/CompoundAnnotationUtilsTest.java
@@ -42,6 +42,7 @@ import io.github.mzmine.datamodel.features.types.annotations.iin.IonTypeType;
 import io.github.mzmine.datamodel.features.types.numbers.MZType;
 import io.github.mzmine.datamodel.identities.iontype.IonModification;
 import io.github.mzmine.datamodel.identities.iontype.IonType;
+import io.github.mzmine.util.collections.SortOrder;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
@@ -110,8 +111,17 @@ class CompoundAnnotationUtilsTest {
     List<DataType> types = DataTypes.getAll(FormulaType.class, MZType.class, SmilesStructureType.class,
         LipidMatchListType.class, SpectralLibraryMatchesType.class, MissingValueType.class,
         MissingValueType.class);
-    var map = CompoundAnnotationUtils.rankUniqueAnnotationTypes((Collection) types);
+    var map = CompoundAnnotationUtils.rankUniqueAnnotationTypes((Collection) types,
+        SortOrder.DESCENDING);
     assertEquals(3, map.size());
     assertEquals(0, map.get(DataTypes.get(SpectralLibraryMatchesType.class)));
+    assertEquals(1, map.get(DataTypes.get(LipidMatchListType.class)));
+    assertEquals(2, map.get(DataTypes.get(MissingValueType.class)));
+    map = CompoundAnnotationUtils.rankUniqueAnnotationTypes((Collection) types,
+        SortOrder.ASCENDING);
+    assertEquals(3, map.size());
+    assertEquals(0, map.get(DataTypes.get(MissingValueType.class)));
+    assertEquals(1, map.get(DataTypes.get(LipidMatchListType.class)));
+    assertEquals(2, map.get(DataTypes.get(SpectralLibraryMatchesType.class)));
   }
 }

--- a/utils/src/main/java/io/github/mzmine/util/collections/CollectionUtils.java
+++ b/utils/src/main/java/io/github/mzmine/util/collections/CollectionUtils.java
@@ -29,8 +29,8 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +51,7 @@ public class CollectionUtils {
    * @return Map object to index in collection
    */
   public static <T> Map<T, Integer> indexMap(Collection<T> list) {
-    Map<T, Integer> map = new HashMap<>();
+    Map<T, Integer> map = new LinkedHashMap<>(list.size());
     int i = 0;
     for (final T value : list) {
       map.put(value, i);
@@ -67,7 +67,7 @@ public class CollectionUtils {
    * @return Map object to index in collection
    */
   public static <T> Map<T, Integer> indexMap(T[] array) {
-    Map<T, Integer> map = new HashMap<>();
+    Map<T, Integer> map = new LinkedHashMap<>(array.length);
     for (int i = 0; i < array.length; i++) {
       map.put(array[i], i);
     }

--- a/utils/src/main/java/io/github/mzmine/util/collections/SortOrder.java
+++ b/utils/src/main/java/io/github/mzmine/util/collections/SortOrder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2004-2024 The MZmine Development Team
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.github.mzmine.util.collections;
+
+import java.util.Comparator;
+
+public enum SortOrder {
+  ASCENDING, DESCENDING;
+
+  public Comparator<? super Integer> intComparator() {
+    return this == ASCENDING ? Comparator.naturalOrder() : Comparator.reverseOrder();
+  }
+}


### PR DESCRIPTION
I fixed the issue that I introduced with the order of the datasets.
Now we can more easily control that MissingType should be first and all others should come after.