### PR TITLE
Load old mz tolerance parameter from optional to required

### DIFF
--- a/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderParameters.java
+++ b/mzmine-community/src/main/java/io/github/mzmine/modules/dataprocessing/featdet_imsexpander/ImsExpanderParameters.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004-2022 The MZmine Development Team
+ * Copyright (c) 2004-2025 The mzmine Development Team
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -37,7 +37,9 @@ import io.github.mzmine.parameters.parametertypes.IntegerParameter;
 import io.github.mzmine.parameters.parametertypes.OptionalParameter;
 import io.github.mzmine.parameters.parametertypes.OriginalFeatureListHandlingParameter;
 import io.github.mzmine.parameters.parametertypes.selectors.FeatureListsParameter;
+import io.github.mzmine.parameters.parametertypes.tolerances.MZTolerance;
 import io.github.mzmine.parameters.parametertypes.tolerances.MZToleranceParameter;
+import io.github.mzmine.parameters.parametertypes.tolerances.ToleranceType;
 import java.util.Collection;
 import java.util.Map;
 import org.jetbrains.annotations.NotNull;
@@ -47,26 +49,34 @@ public class ImsExpanderParameters extends SimpleParameterSet {
 
   public static final FeatureListsParameter featureLists = new FeatureListsParameter();
 
-  public static final MZToleranceParameter mzTolerance = new MZToleranceParameter("m/z tolerance",
-      """
-          m/z tolerance for peaks in the mobility dimension. The given tolerance will be applied to the feature m/z.
-          Default = 0.005 m/z and 20 ppm.
-          """, 0.005, 20);
+  // name had to be changed in ~v4.5.50 because old mz tolerance was optional now it is required
+  public static final MZToleranceParameter mzTolerance = new MZToleranceParameter(
+      ToleranceType.SCAN_TO_SCAN, """
+      m/z tolerance for peaks in the mobility dimension. The given tolerance will be applied to the feature m/z.
+      Default = 0.005 m/z and 20 ppm.
+      """, 0.005, 20);
+
+
+  private final OptionalParameter<MZToleranceParameter> oldOptionalMzTolerance = new OptionalParameter<>(
+      new MZToleranceParameter("m/z tolerance",
+          "m/z tolerance for peaks in the mobility dimension. If enabled, the given "
+          + "tolerance will be applied to the feature m/z. If disabled, the m/z range of the "
+          + "feature's data points will be used as a tolerance range."));
 
   public static final OptionalParameter<DoubleParameter> useRawData = new OptionalParameter<>(
       new DoubleParameter("Raw data instead of thresholded",
           "If checked, the raw data can be used to expand the chromatograms into mobility dimension.\n"
-              + "This can increase sensitivity but will also increase RAM demands and computation time.\n"
-              + "A new noise level can be given or every data point can be used (0E0)",
+          + "This can increase sensitivity but will also increase RAM demands and computation time.\n"
+          + "A new noise level can be given or every data point can be used (0E0)",
           MZmineCore.getConfiguration().getIntensityFormat(), 1E1, 0d, Double.POSITIVE_INFINITY),
       true);
 
   public static final OptionalParameter<IntegerParameter> mobilogramBinWidth = new OptionalParameter<>(
       new IntegerParameter("Override default mobility bin width (scans)",
           "If checked, the default recommended bin width for the raw data file will be overridden with the given value.\n"
-              + "The mobility binning width in scans. (high mobility resolutions "
-              + "in TIMS might require a higher bin width to achieve a constant ion current for a "
-              + "mobilogram.", 1, true), false);
+          + "The mobility binning width in scans. (high mobility resolutions "
+          + "in TIMS might require a higher bin width to achieve a constant ion current for a "
+          + "mobilogram.", 1, true), false);
 
   public static final OriginalFeatureListHandlingParameter handleOriginal = //
       new OriginalFeatureListHandlingParameter(false);
@@ -97,16 +107,16 @@ public class ImsExpanderParameters extends SimpleParameterSet {
     for (ModularFeatureList flist : matchingFeatureLists) {
       if (flist.getNumberOfRawDataFiles() > 1) {
         errorMessages.add("Feature list " + flist.getName()
-            + " is an aligned feature list. Please expand before alignment.");
+                          + " is an aligned feature list. Please expand before alignment.");
       }
 
       if (((IMSRawDataFile) flist.getRawDataFile(0)).getFrame(0).getMobilityScan(0)
-          .getSpectrumType() != MassSpectrumType.CENTROIDED
+              .getSpectrumType() != MassSpectrumType.CENTROIDED
           && getParameter(useRawData).getValue() == true) {
         errorMessages.add(
             "Feature list " + flist.getName() + " contains raw data file " + flist.getRawDataFile(0)
-                + " which has profile raw data.\nCannot use profile raw data to expand in mobility dimension. Please disable the \""
-                + useRawData.getName() + "\" parameter.");
+            + " which has profile raw data.\nCannot use profile raw data to expand in mobility dimension. Please disable the \""
+            + useRawData.getName() + "\" parameter.");
       }
     }
 
@@ -119,11 +129,27 @@ public class ImsExpanderParameters extends SimpleParameterSet {
   }
 
   @Override
+  public void handleLoadedParameters(final Map<String, Parameter<?>> loadedParams) {
+    super.handleLoadedParameters(loadedParams);
+
+    // old parameters are non-static so can be used directly
+    if (loadedParams.containsKey(oldOptionalMzTolerance.getName())) {
+      // could also check if the optional parameter was checked?
+      final MZTolerance mzTol = oldOptionalMzTolerance.getEmbeddedParameter().getValue();
+      if (mzTol != null) {
+        mzTolerance.setValue(mzTol);
+      }
+    }
+  }
+
+  @Override
   public Map<String, Parameter<?>> getNameParameterMap() {
 
     final Map<String, Parameter<?>> map = super.getNameParameterMap();
     map.put("Override default mobility bin witdh (scans)",
         getParameter(ImsExpanderParameters.mobilogramBinWidth));
+    // private - non-static
+    map.put("m/z tolerance", oldOptionalMzTolerance);
     return map;
   }
 
@@ -135,7 +161,8 @@ public class ImsExpanderParameters extends SimpleParameterSet {
   @Override
   public @Nullable String getVersionMessage(int version) {
     return switch (version) {
-      case 2 -> "The previously optional m/z range parameter in the IMS expander is not optional anymore and must be specified now.";
+      case 2 ->
+          "The previously optional m/z tolerance parameter in the IMS expander now requires a value. The mz tolerance will be loaded from configuration files if it was defined.";
       default -> null;
     };
   }


### PR DESCRIPTION
Had to try if it works - so here is a PR on your branch. 
You can load the old optional mz tolerance and unpack it into the new required mz tolerance parameter. 
Only thing is you have to rename the new parameter (kind of annoying). Maybe mz tolerance (scan-to-scan) although it is more feature-to-mobility-scan? 
But then it is loaded. 

I think it is worth it but your call. 